### PR TITLE
Fix review findings: refuter default verdict, subagent harness hedge, preflight comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,4 @@ For any hard, multi-step, or ambiguous task, run this loop (full detail in `skil
 
 Red flags: "obviously fine, skip the check" · "I'll verify everything at the end" · "need more context" when no answer changes the plan · "the fix works for the reported case" with siblings unchecked.
 
-References: `skills/fable-5/references/verification-catalog.md` (smallest failing check per task type), `skills/fable-5/references/decomposition-patterns.md`. Pre-completion sweep: `skills/fable-5/scripts/preflight.sh`. Agent prompt templates: `skills/fable-5/agents/` (scout = read-only comprehension; refuter = adversarial verification, defaults to REFUTED).
+References: `skills/fable-5/references/verification-catalog.md` (smallest failing check per task type), `skills/fable-5/references/decomposition-patterns.md`. Pre-completion sweep: `skills/fable-5/scripts/preflight.sh`. Agent prompt templates: `skills/fable-5/agents/` (scout = read-only comprehension; refuter = adversarial verification — REFUTED only with a concrete failing case, defaults to UNVERIFIABLE).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built by [LearNer](https://github.com/Learn57130).
 ## Contents
 
 - `skills/fable-5/` — the skill: 8-step loop, verification catalog (smallest failing check per task type), decomposition patterns, `preflight.sh` pre-completion sweep.
-- `skills/fable-5/agents/` — `fable-scout` (read-only comprehension pass) and `fable-refuter` (adversarial verifier, defaults to REFUTED when uncertain). Registered automatically on plugin install; also usable as plain prompt templates in other harnesses.
+- `skills/fable-5/agents/` — `fable-scout` (read-only comprehension pass) and `fable-refuter` (adversarial verifier — REFUTED only with a concrete failing case, defaults to UNVERIFIABLE when uncertain). Registered automatically on plugin install; also usable as plain prompt templates in other harnesses.
 
 ## Install
 

--- a/skills/fable-5/SKILL.md
+++ b/skills/fable-5/SKILL.md
@@ -98,7 +98,7 @@ Test: would ANY content of that file change what I do next?
 
 ## Subagents in the Loop
 
-If the host harness has an agent/subagent tool, map it onto the loop:
+If the host harness has an agent/subagent tool AND permits proactive dispatch, map it onto the loop as below. Harness policy wins: some harnesses restrict agent spawning to explicit user request (cold-start cost) — there, run the loop solo and dispatch only when the user asks.
 
 - **Step 1 (read fully)**: dispatch `fable-scout` agents in parallel (one per subsystem) for the scout pass; keep conclusions, not file dumps.
 - **Step 4 (fan out reads)**: independent searches/reads go to parallel agents in one dispatch; any judgment-dependent work stays serialized in the main context.

--- a/skills/fable-5/scripts/preflight.sh
+++ b/skills/fable-5/scripts/preflight.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # preflight.sh — pre-completion sweep before declaring a code task done.
-# Usage: preflight.sh [dir]   (defaults to current directory; scans git-tracked
-# changes if in a repo, else the whole dir)
+# Usage: preflight.sh [dir]   (defaults to current directory; in a git repo scans
+# uncommitted changes + untracked files, else the whole dir)
 # Exit 0 = clean, 1 = findings to review. Findings are prompts, not verdicts.
 set -euo pipefail
 
@@ -12,7 +12,7 @@ FOUND=0
 scan() { # scan <label> <grep-pattern>
   local label="$1" pattern="$2" hits
   if git rev-parse --git-dir >/dev/null 2>&1; then
-    # only files touched on this branch/working tree
+    # uncommitted changes vs HEAD + untracked files; commits already on the branch are NOT scanned
     hits=$( { git diff --name-only HEAD 2>/dev/null; git ls-files --others --exclude-standard; } \
       | sort -u | xargs grep -lnE "$pattern" 2>/dev/null || true)
   else


### PR DESCRIPTION
Three findings from a self-review of the skill (run with the skill's own loop — every finding below was confirmed by an executed check, not by reading):

## 1. Docs contradict the refuter's verdict policy (CONFIRMED)
`AGENTS.md` and `README.md` said the refuter "defaults to REFUTED", but the actual agent definition (`agents/fable-refuter.md`) and the SKILL.md dispatch template both say "Default to UNVERIFIABLE … use REFUTED only with a concrete failing case." The agent's version is the correct one — REFUTED without a failing case is an unsupported accusation, which violates the skill's own reporting rules. Summaries now match the agent.

## 2. Subagent section ignores harness dispatch policy
"Subagents in the Loop" unconditionally encouraged proactive scout/refuter dispatch, but some harnesses restrict agent spawning to explicit user request (cold-start cost). The section now defers to harness policy and falls back to running the loop solo.

## 3. preflight.sh comments claim branch-wide scanning it doesn't do (CONFIRMED)
The git-mode comment said "only files touched on this branch/working tree", but the implementation (`git diff --name-only HEAD` + untracked) scans only uncommitted changes — a FIXME committed on the branch is not scanned (verified: committed a `# FIXME` file, script exited 0). Comments now describe the actual behavior; scanning branch commits was rejected because it requires guessing the base branch, which is more fragile than the current scope.

All changes verified after editing: `bash -n` clean, dirty dir → exit 1, clean dir → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)